### PR TITLE
Disk buffering - pulled latest changes from v2

### DIFF
--- a/const.go
+++ b/const.go
@@ -21,6 +21,7 @@ var blacklistExtensions []string
 var isBlacklisted int
 var diggedURLs []string
 var urlAssets []string
+var regexList map[string]string
 var domAssets []string
 var unscannable []string
 var subAssets []string

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 				}
 				for _, bucketEntry := range iniFileListData.ScanData {
 					if *slowScan {
-						scanS3FileSlow(bucketEntry.IntFiles, bucketEntry.URL)
+						scanS3FilesSlow(bucketEntry.IntFiles, bucketEntry.URL)
 					} else {
 						scanS3FilesFast(bucketEntry.IntFiles, bucketEntry.URL)
 					}


### PR DESCRIPTION
The tool would previously freeze if S3 buckets had giant objects. This is due to RAM being consumed rapidly, causing the machine to freeze. This was highlighted in #3.

Fix: 
1. Download all files from S3 first using goroutines in a loop
2. Write them to a temp directory
3. End the loop, release all mutex locks.
4. Read the newly downloaded files from the temp directory and process them using goroutines in a loop

Note: This fix is apparent in fast mode only. Since slow mode works sequentially anyway, not much is needed there.