### PR TITLE
Bumps golang.org/x/net from 0.17.0 to 0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )


### PR DESCRIPTION
golang.org/x@0.17.0 introduces two vulnerabilities. Upgrading to version 0.23 fixed those issue.

**References:**
https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2-6531285
https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-6130669